### PR TITLE
SCRUM-122: Adjust EventCard width to a suitable value

### DIFF
--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -36,7 +36,7 @@ function EventCard({ event, hostName }) {
     <Card
       onClick={goToDetails}
       sx={{
-        width: 280,
+        width: 380,
         boxShadow: 3,
         cursor: "pointer",
         position: "relative",


### PR DESCRIPTION
Set width to 380 to improve UI and eliminate issue with long event titles