### PR TITLE
SCRUM-129: Fix Starting Soon Banner  Placement

### DIFF
--- a/frontend/src/components/SearchEventCard.js
+++ b/frontend/src/components/SearchEventCard.js
@@ -122,7 +122,7 @@ function SearchEventCard({ event }) {
           <Box
             sx={{
               position: "absolute",
-              bottom: 12,
+              top: 12,
               left: -30,
               width: 120,
               backgroundColor: "orange",


### PR DESCRIPTION
Corrected banner position placement for "starting soon" to top.  It was set to bottom by accident.  